### PR TITLE
Improve policy import messages

### DIFF
--- a/enforcer/src/db/dbw.c
+++ b/enforcer/src/db/dbw.c
@@ -1621,6 +1621,7 @@ dbw_new_policy(struct dbw_db *db)
     r |= list_add(db->policies, (struct dbrow *)policy);
     /* TODO handle errors */
     policy->dirty = DBW_INSERT;
+    policy->denial_salt = strdup("");
     return policy;
 }
 


### PR DESCRIPTION
Set policy scratch to 1 for unchanged policy, 2 for just created one, and 3 for updated one
Schedule resalt task if the salt length has changed